### PR TITLE
Create credentials schema

### DIFF
--- a/segurata/schemas/credentials.json
+++ b/segurata/schemas/credentials.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "$id": "https://github.com/diegovincent/segurata/tree/master/segurata/schemas/credentials.json",
+  "title": "Credentials schema",
+  "type": "object",
+  "properties": {
+    "username": { "type": "string" },
+    "password": { "type": "string" }
+  },
+  "additionalProperties": false,
+  "required": ["username", "password"]
+}


### PR DESCRIPTION
I propose creating the first schemas for `segurata`. For now, I think these are essential for the MVP release:

1. Credentials (User + Pass). I propose `credentials`.
2. URLs to parse (`start_urls` would be good name since it would follow Scrapy convention). This is ONLY the schema of URLs to parse, therefore we would define only a schema based on the schema.org ListOfItems maybe.
3. Fields to scrape. I propose `fields`. Simple, generic and it could be use to dynamically create Scrapy Fields as well.

There is still a discussion to be had...

I propose following the `schema.org` standard and validate it using any implementations of json-schema. In the meantime, we can just use [this](https://www.jsonschemavalidator.net/) to do it manually.