### PR TITLE
Implement AuthSpider

### DIFF
--- a/segurata/enginee/enginee/login/login.py
+++ b/segurata/enginee/enginee/login/login.py
@@ -39,20 +39,11 @@ def login_request(
     )
 
 
-def check_login(response: Response, **kwargs) -> Request:
+def check_login(response: Response, selector: str, *args, **kwargs) -> Request:
     'Return a parametric Request if the user is logged in.'
-    check_login_selector = kwargs.get('selector')
-    matching_elements = response.css(check_login_selector)
-
+    matching_elements = response.css(selector)
     if not matching_elements:
-        raise NotLoggedInError()
-
-    after_login_url = kwargs.get('after_login_url')
-
-    return Request(
-        url=after_login_url,
-        meta={'cookiejar': 0},
-    )
+        raise NotLoggedInError('Could not log in. Maybe try changing selector?')
 
 
 def dumb_callback(response: Response) -> None:

--- a/segurata/enginee/enginee/settings.py
+++ b/segurata/enginee/enginee/settings.py
@@ -70,7 +70,7 @@ ROBOTSTXT_OBEY = True
 
 # Enable and configure the AutoThrottle extension (disabled by default)
 # See https://docs.scrapy.org/en/latest/topics/autothrottle.html
-#AUTOTHROTTLE_ENABLED = True
+AUTOTHROTTLE_ENABLED = True
 # The initial download delay
 #AUTOTHROTTLE_START_DELAY = 5
 # The maximum download delay to be set in case of high latencies

--- a/segurata/enginee/example_config.json
+++ b/segurata/enginee/example_config.json
@@ -1,9 +1,0 @@
-{
-    "login_url": "https://www.obasketball.com/index.php?route=account/login",
-    "check_login_css": "div.col-sm-12#content h2",
-    "after_login_url": "https://www.obasketball.com/",
-    "credentials" : {
-      "username": "ilove@segurata.com",
-      "password": "olovorg0"
-    }
-  }

--- a/segurata/enginee/item.json
+++ b/segurata/enginee/item.json
@@ -1,0 +1,3 @@
+[
+{"name": ["<h1 style=\"margin-bottom:10px;font-size:28px; text-transform:uppercase\">Women\u2019s Air Jordan 1 Retro High \u201cSunset Tint\u201d AO1847-645</h1>"], "price": ["<h2>$84.00</h2>"]}
+]

--- a/segurata/enginee/login_plus_scrape_example.json
+++ b/segurata/enginee/login_plus_scrape_example.json
@@ -1,0 +1,20 @@
+{
+    "start_urls": [
+      "https://www.obasketball.com/air-jordan-1-gs/women%E2%80%99s-air-jordan-1-retro-high-%E2%80%9Csunset-tint%E2%80%9D-ao1847-645.html"
+    ],
+    "login_url": "https://www.obasketball.com/index.php?route=account/login",
+    "check_login_css_selector": "div.col-sm-12#content h2",
+    "credentials" : {
+      "username": "ilove@segurata.com",
+      "password": "olovorg0"
+    },
+    "schemas": [
+      {
+        "schema_name": "Product",
+        "properties": {
+          "name": "h1",
+          "price": "li h2"
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
This commit has the first working implementation of the AuthSpider. It proposes changes and assumptions:

1. The spider will ONLY log in, and scrape for URL in `start_urls`. To simplify the process even more, crawling was taken out of the equation, making it easier and separating crawling + scraping from the very beginning. In a future, if we want to crawl with login and then not logging in again, we could create a system where the session is received as input as well (cookies essentially).

2. I made some changes to the JSON configuration file proposed in #6 and #7. But that's why this is a draft and needs to be discussed.

3. Since the spider is no longer crawling, we now inherit from `Spider` instead of `CrawlSpider`.

Also, there is still work to do! 

The spider seems to be functional, however there is no executable file and I think that we will need to drastically change and simplify the spider structure, which is daunting and exciting at the same time. How? By eliminating all but the spider and login module that we've created. That is, eliminating pipelines, items, settings, etc. I think Scrapy can work without all of that, and we just need to master executing the spider from a Python script—or using `CrawlerProcess`—instead of using `scrapy crawl` or something like that.

The cost could be high, but we will simplify drastically the project (no additional enginee folders, and thus we get more flexibility and also, the simpler, the less mistakes).

That's all. Sorry for the long message, here's a potato. :potato: 

@sergipastor @sarafg11 Tell me your thoughts.